### PR TITLE
chore: bump Scrubbler.Dependencies to v1.0.1

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,8 @@
+{
+  "msbuild-sdks": {
+    "Uno.Sdk": "6.5.31"
+  },
+  "sdk": {
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
This PR bumps the Scrubbler.Dependencies submodule to tag v1.0.1 (1a20b3675a9ebf42ad238f39fce472f727d7448b).