### PR TITLE
chore: bump Scrubbler.Dependencies to v1.1.5

### DIFF
--- a/Scrubbler/Scrubbler.Host/App.xaml
+++ b/Scrubbler/Scrubbler.Host/App.xaml
@@ -3,7 +3,7 @@
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        xmlns:utum="using:Uno.Toolkit.UI.Material"
        xmlns:helper="using:Scrubbler.Host.Helper"
-       xmlns:conv="using:Scrubbler.Abstractions.Converter">
+       xmlns:conv="using:Scrubbler.PluginBase.Converter">
 
     <Application.Resources>
         <ResourceDictionary>

--- a/Scrubbler/Scrubbler.Host/App.xaml.cs
+++ b/Scrubbler/Scrubbler.Host/App.xaml.cs
@@ -1,6 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using Scrubbler.Abstractions.Services;
-using Scrubbler.Abstractions.Settings;
 using Scrubbler.Host.Presentation.Accounts;
 using Scrubbler.Host.Presentation.Logging;
 using Scrubbler.Host.Presentation.Plugins;
@@ -9,6 +7,8 @@ using Scrubbler.Host.Services;
 using Scrubbler.Host.Services.Logging;
 using Scrubbler.Host.Updates;
 using Scrubbler.PluginBase.Discord;
+using Scrubbler.PluginBase.Services;
+using Scrubbler.PluginBase.Settings;
 
 namespace Scrubbler.Host;
 

--- a/Scrubbler/Scrubbler.Host/Presentation/Accounts/AccountPluginViewModel.cs
+++ b/Scrubbler/Scrubbler.Host/Presentation/Accounts/AccountPluginViewModel.cs
@@ -1,5 +1,5 @@
 using CommunityToolkit.Mvvm.Input;
-using Scrubbler.Abstractions.Plugin.Account;
+using Scrubbler.PluginBase.Plugin.Account;
 
 
 namespace Scrubbler.Host.Presentation.Accounts;

--- a/Scrubbler/Scrubbler.Host/Presentation/Accounts/AccountsView.xaml
+++ b/Scrubbler/Scrubbler.Host/Presentation/Accounts/AccountsView.xaml
@@ -5,7 +5,7 @@
     xmlns:local="using:Scrubbler.Host.Presentation.Accounts"
     xmlns:beh="using:Microsoft.Xaml.Interactivity"
     xmlns:actions="using:Microsoft.Xaml.Interactions.Core"
-    xmlns:acc="using:Scrubbler.Abstractions.Plugin.Account"
+    xmlns:acc="using:Scrubbler.PluginBase.Plugin.Account"
     xmlns:utu="using:Uno.Toolkit.UI"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     d:DataContext="{d:DesignInstance Type=local:AccountsViewModel}">

--- a/Scrubbler/Scrubbler.Host/Presentation/Accounts/AccountsViewModel.cs
+++ b/Scrubbler/Scrubbler.Host/Presentation/Accounts/AccountsViewModel.cs
@@ -1,7 +1,7 @@
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
-using Scrubbler.Abstractions.Plugin.Account;
 using Scrubbler.Host.Services;
+using Scrubbler.PluginBase.Plugin.Account;
 
 namespace Scrubbler.Host.Presentation.Accounts;
 

--- a/Scrubbler/Scrubbler.Host/Presentation/Logging/LogViewModel.cs
+++ b/Scrubbler/Scrubbler.Host/Presentation/Logging/LogViewModel.cs
@@ -1,9 +1,9 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.Input;
-using Scrubbler.Abstractions.Services;
 using Scrubbler.Host.Presentation.Navigation;
 using Scrubbler.Host.Services;
 using Scrubbler.Host.Services.Logging;
+using Scrubbler.PluginBase.Services;
 
 namespace Scrubbler.Host.Presentation.Logging;
 

--- a/Scrubbler/Scrubbler.Host/Presentation/MainPage.xaml.cs
+++ b/Scrubbler/Scrubbler.Host/Presentation/MainPage.xaml.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
-using Scrubbler.Abstractions.Services;
 using Scrubbler.Host.Services;
+using Scrubbler.PluginBase.Services;
 
 namespace Scrubbler.Host.Presentation;
 

--- a/Scrubbler/Scrubbler.Host/Presentation/MainViewModel.cs
+++ b/Scrubbler/Scrubbler.Host/Presentation/MainViewModel.cs
@@ -1,13 +1,13 @@
 using System.Collections.ObjectModel;
 using Microsoft.Extensions.DependencyInjection;
-using Scrubbler.Abstractions.Plugin;
-using Scrubbler.Abstractions.Services;
 using Scrubbler.Host.Presentation.Accounts;
 using Scrubbler.Host.Presentation.Logging;
 using Scrubbler.Host.Presentation.Navigation;
 using Scrubbler.Host.Presentation.Plugins;
 using Scrubbler.Host.Presentation.Settings;
 using Scrubbler.Host.Services;
+using Scrubbler.PluginBase.Plugin;
+using Scrubbler.PluginBase.Services;
 
 namespace Scrubbler.Host.Presentation;
 

--- a/Scrubbler/Scrubbler.Host/Presentation/Navigation/PluginNavigationItemViewModel.cs
+++ b/Scrubbler/Scrubbler.Host/Presentation/Navigation/PluginNavigationItemViewModel.cs
@@ -1,7 +1,7 @@
-using Scrubbler.Abstractions.Plugin;
-using Scrubbler.Abstractions.Services;
 using Scrubbler.Host.Presentation.Plugins;
 using Scrubbler.Host.Services;
+using Scrubbler.PluginBase.Plugin;
+using Scrubbler.PluginBase.Services;
 
 namespace Scrubbler.Host.Presentation.Navigation;
 

--- a/Scrubbler/Scrubbler.Host/Presentation/Plugins/AutoScrobblePluginHostViewModel.cs
+++ b/Scrubbler/Scrubbler.Host/Presentation/Plugins/AutoScrobblePluginHostViewModel.cs
@@ -1,7 +1,7 @@
-using Scrubbler.Abstractions;
-using Scrubbler.Abstractions.Plugin;
-using Scrubbler.Abstractions.Services;
 using Scrubbler.Host.Services;
+using Scrubbler.PluginBase;
+using Scrubbler.PluginBase.Plugin;
+using Scrubbler.PluginBase.Services;
 
 namespace Scrubbler.Host.Presentation.Plugins;
 

--- a/Scrubbler/Scrubbler.Host/Presentation/Plugins/AvailablePluginsViewModel.cs
+++ b/Scrubbler/Scrubbler.Host/Presentation/Plugins/AvailablePluginsViewModel.cs
@@ -1,7 +1,7 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.Input;
-using Scrubbler.Abstractions.Plugin;
 using Scrubbler.Host.Services;
+using Scrubbler.PluginBase.Plugin;
 
 namespace Scrubbler.Host.Presentation.Plugins;
 

--- a/Scrubbler/Scrubbler.Host/Presentation/Plugins/InstalledPluginViewModel.cs
+++ b/Scrubbler/Scrubbler.Host/Presentation/Plugins/InstalledPluginViewModel.cs
@@ -1,5 +1,5 @@
 using CommunityToolkit.Mvvm.Input;
-using Scrubbler.Abstractions.Plugin;
+using Scrubbler.PluginBase.Plugin;
 
 namespace Scrubbler.Host.Presentation.Plugins;
 

--- a/Scrubbler/Scrubbler.Host/Presentation/Plugins/InstalledPluginsViewModel.cs
+++ b/Scrubbler/Scrubbler.Host/Presentation/Plugins/InstalledPluginsViewModel.cs
@@ -1,7 +1,7 @@
 using System.Collections.ObjectModel;
-using Scrubbler.Abstractions.Plugin;
 using Scrubbler.Host.Presentation.Navigation;
 using Scrubbler.Host.Services;
+using Scrubbler.PluginBase.Plugin;
 
 namespace Scrubbler.Host.Presentation.Plugins;
 

--- a/Scrubbler/Scrubbler.Host/Presentation/Plugins/PluginHostViewModelBase.cs
+++ b/Scrubbler/Scrubbler.Host/Presentation/Plugins/PluginHostViewModelBase.cs
@@ -1,8 +1,8 @@
-using Scrubbler.Abstractions;
-using Scrubbler.Abstractions.Plugin;
-using Scrubbler.Abstractions.Plugin.Account;
-using Scrubbler.Abstractions.Services;
 using Scrubbler.Host.Services;
+using Scrubbler.PluginBase;
+using Scrubbler.PluginBase.Plugin;
+using Scrubbler.PluginBase.Plugin.Account;
+using Scrubbler.PluginBase.Services;
 
 namespace Scrubbler.Host.Presentation.Plugins;
 

--- a/Scrubbler/Scrubbler.Host/Presentation/Plugins/PluginMetadataViewModel.cs
+++ b/Scrubbler/Scrubbler.Host/Presentation/Plugins/PluginMetadataViewModel.cs
@@ -1,6 +1,6 @@
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
-using Scrubbler.Abstractions.Plugin;
+using Scrubbler.PluginBase.Plugin;
 
 namespace Scrubbler.Host.Presentation.Plugins;
 internal partial class PluginMetadataViewModel(PluginManifestEntry meta) : ObservableObject

--- a/Scrubbler/Scrubbler.Host/Presentation/Plugins/ScrobblePluginHostViewModel.cs
+++ b/Scrubbler/Scrubbler.Host/Presentation/Plugins/ScrobblePluginHostViewModel.cs
@@ -1,7 +1,7 @@
 using CommunityToolkit.Mvvm.Input;
-using Scrubbler.Abstractions.Plugin;
-using Scrubbler.Abstractions.Services;
 using Scrubbler.Host.Services;
+using Scrubbler.PluginBase.Plugin;
+using Scrubbler.PluginBase.Services;
 
 namespace Scrubbler.Host.Presentation.Plugins;
 

--- a/Scrubbler/Scrubbler.Host/Presentation/Plugins/ScrobblePreviewDialog.xaml
+++ b/Scrubbler/Scrubbler.Host/Presentation/Plugins/ScrobblePreviewDialog.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:models="using:Scrubbler.Abstractions"
+    xmlns:models="using:Scrubbler.PluginBase"
     mc:Ignorable="d"
     Title="Scrobble Preview"
     PrimaryButtonText="OK"

--- a/Scrubbler/Scrubbler.Host/Presentation/Plugins/ScrobblePreviewDialog.xaml.cs
+++ b/Scrubbler/Scrubbler.Host/Presentation/Plugins/ScrobblePreviewDialog.xaml.cs
@@ -1,4 +1,4 @@
-using Scrubbler.Abstractions;
+using Scrubbler.PluginBase;
 
 namespace Scrubbler.Host.Presentation.Plugins;
 

--- a/Scrubbler/Scrubbler.Host/Presentation/Plugins/ScrobblePreviewViewModel.cs
+++ b/Scrubbler/Scrubbler.Host/Presentation/Plugins/ScrobblePreviewViewModel.cs
@@ -1,5 +1,5 @@
-using Scrubbler.Abstractions;
 using System.Collections.ObjectModel;
+using Scrubbler.PluginBase;
 
 namespace Scrubbler.Host.Presentation.Plugins;
 

--- a/Scrubbler/Scrubbler.Host/Presentation/Settings/AboutSettingsCategoryViewModel.cs
+++ b/Scrubbler/Scrubbler.Host/Presentation/Settings/AboutSettingsCategoryViewModel.cs
@@ -1,7 +1,7 @@
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.WinUI;
-using Scrubbler.Abstractions.Services;
 using Scrubbler.Host.Services;
+using Scrubbler.PluginBase.Services;
 
 namespace Scrubbler.Host.Presentation.Settings;
 

--- a/Scrubbler/Scrubbler.Host/Presentation/Settings/SettingsViewModel.cs
+++ b/Scrubbler/Scrubbler.Host/Presentation/Settings/SettingsViewModel.cs
@@ -1,6 +1,6 @@
 using System.Collections.ObjectModel;
-using Scrubbler.Abstractions.Services;
 using Scrubbler.Host.Services;
+using Scrubbler.PluginBase.Services;
 
 namespace Scrubbler.Host.Presentation.Settings;
 

--- a/Scrubbler/Scrubbler.Host/Services/IPluginManager.cs
+++ b/Scrubbler/Scrubbler.Host/Services/IPluginManager.cs
@@ -1,4 +1,4 @@
-using Scrubbler.Abstractions.Plugin;
+using Scrubbler.PluginBase.Plugin;
 
 namespace Scrubbler.Host.Services;
 

--- a/Scrubbler/Scrubbler.Host/Services/Logging/ModuleLogService.cs
+++ b/Scrubbler/Scrubbler.Host/Services/Logging/ModuleLogService.cs
@@ -1,4 +1,4 @@
-using Scrubbler.Abstractions.Services;
+using Scrubbler.PluginBase.Services;
 
 namespace Scrubbler.Host.Services.Logging;
 

--- a/Scrubbler/Scrubbler.Host/Services/Logging/ModuleLogServiceFactory.cs
+++ b/Scrubbler/Scrubbler.Host/Services/Logging/ModuleLogServiceFactory.cs
@@ -1,4 +1,4 @@
-using Scrubbler.Abstractions.Services;
+using Scrubbler.PluginBase.Services;
 
 namespace Scrubbler.Host.Services.Logging;
 

--- a/Scrubbler/Scrubbler.Host/Services/PluginManager.cs
+++ b/Scrubbler/Scrubbler.Host/Services/PluginManager.cs
@@ -1,11 +1,11 @@
 using System.Reflection;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
-using Scrubbler.Abstractions.Plugin;
-using Scrubbler.Abstractions.Plugin.Account;
-using Scrubbler.Abstractions.Services;
-using Scrubbler.Abstractions.Settings;
 using Scrubbler.Host.Helper;
+using Scrubbler.PluginBase.Plugin;
+using Scrubbler.PluginBase.Plugin.Account;
+using Scrubbler.PluginBase.Services;
+using Scrubbler.PluginBase.Settings;
 
 namespace Scrubbler.Host.Services;
 

--- a/Scrubbler/Scrubbler.Host/Services/WindowHandleProvider.cs
+++ b/Scrubbler/Scrubbler.Host/Services/WindowHandleProvider.cs
@@ -1,4 +1,4 @@
-using Scrubbler.Abstractions.Services;
+using Scrubbler.PluginBase.Services;
 
 namespace Scrubbler.Host.Services;
 

--- a/Scrubbler/Scrubbler.Test/Presentation/Accounts/AccountPluginViewModelTests.cs
+++ b/Scrubbler/Scrubbler.Test/Presentation/Accounts/AccountPluginViewModelTests.cs
@@ -2,9 +2,9 @@ using System.ComponentModel;
 
 #nullable enable
 using Moq;
-using Scrubbler.Abstractions.Plugin.Account;
 using Scrubbler.Host.Models;
 using Scrubbler.Host.Presentation.Accounts;
+using Scrubbler.PluginBase.Plugin.Account;
 
 namespace Scrubbler.Test.Presentation.Accounts;
 

--- a/Scrubbler/Scrubbler.Test/Presentation/Accounts/AccountsViewModelTests.cs
+++ b/Scrubbler/Scrubbler.Test/Presentation/Accounts/AccountsViewModelTests.cs
@@ -1,9 +1,9 @@
 using Moq;
-using Scrubbler.Abstractions.Plugin;
-using Scrubbler.Abstractions.Plugin.Account;
 using Scrubbler.Host.Models;
 using Scrubbler.Host.Presentation.Accounts;
 using Scrubbler.Host.Services;
+using Scrubbler.PluginBase.Plugin;
+using Scrubbler.PluginBase.Plugin.Account;
 
 
 namespace Scrubbler.Test.Presentation.Accounts;

--- a/Scrubbler/Scrubbler.Test/Presentation/Logging/LogViewModelTests.cs
+++ b/Scrubbler/Scrubbler.Test/Presentation/Logging/LogViewModelTests.cs
@@ -1,11 +1,11 @@
 using Microsoft.Extensions.Logging;
 using Moq;
-using Scrubbler.Abstractions.Services;
 using Scrubbler.Host.Models;
 using Scrubbler.Host.Presentation.Logging;
 using Scrubbler.Host.Presentation.Navigation;
 using Scrubbler.Host.Services;
 using Scrubbler.Host.Services.Logging;
+using Scrubbler.PluginBase.Services;
 
 namespace Scrubbler.Test.Presentation.Logging;
 

--- a/Scrubbler/Scrubbler.Test/Presentation/Plugins/AvailablePluginsViewModelTests.cs
+++ b/Scrubbler/Scrubbler.Test/Presentation/Plugins/AvailablePluginsViewModelTests.cs
@@ -1,7 +1,7 @@
 using Moq;
-using Scrubbler.Abstractions.Plugin;
 using Scrubbler.Host.Presentation.Plugins;
 using Scrubbler.Host.Services;
+using Scrubbler.PluginBase.Plugin;
 
 namespace Scrubbler.Test.Presentation.Plugins;
 

--- a/Scrubbler/Scrubbler.Test/Presentation/Plugins/InstalledPluginsViewModelTests.cs
+++ b/Scrubbler/Scrubbler.Test/Presentation/Plugins/InstalledPluginsViewModelTests.cs
@@ -1,7 +1,7 @@
 using Moq;
-using Scrubbler.Abstractions.Plugin;
 using Scrubbler.Host.Presentation.Plugins;
 using Scrubbler.Host.Services;
+using Scrubbler.PluginBase.Plugin;
 
 namespace Scrubbler.Test.Presentation.Plugins;
 

--- a/Scrubbler/Scrubbler.Test/Presentation/Plugins/ScrobblePluginHostViewModelTests.cs
+++ b/Scrubbler/Scrubbler.Test/Presentation/Plugins/ScrobblePluginHostViewModelTests.cs
@@ -1,9 +1,9 @@
 using System.ComponentModel;
 using Moq;
-using Scrubbler.Abstractions.Plugin;
-using Scrubbler.Abstractions.Services;
 using Scrubbler.Host.Presentation.Plugins;
 using Scrubbler.Host.Services;
+using Scrubbler.PluginBase.Plugin;
+using Scrubbler.PluginBase.Services;
 
 namespace Scrubbler.Test.Presentation.Plugins;
 


### PR DESCRIPTION
This PR bumps the Scrubbler.Dependencies submodule to tag v1.1.5 (21917e015bf235ae1f9051b6c5b6920dc55583e3).