### PR TITLE
chore: bump Scrubbler.PluginBase to 1.2.1

### DIFF
--- a/Scrubbler/Directory.Packages.props
+++ b/Scrubbler/Directory.Packages.props
@@ -2,6 +2,6 @@
     <Import Project="deps/Directory.Packages.props" />
 
     <ItemGroup>
-        <PackageVersion Include="Scrubbler.PluginBase" Version="1.2.0" />
+        <PackageVersion Include="Scrubbler.PluginBase" Version="1.2.1" />
     </ItemGroup>
 </Project>

--- a/changed-files.txt
+++ b/changed-files.txt
@@ -1,0 +1,1 @@
+Scrubbler/Directory.Packages.props


### PR DESCRIPTION
This PR bumps Scrubbler.PluginBase to 1.2.1 after the NuGet package was published.